### PR TITLE
Allow subfield query on in-memory data without exceptions

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,5 +19,6 @@ Koralium SQL API
    datatypes
    indexsupport
    trinoconnector
+   inmemorydata
    contributordocs
 

--- a/docs/source/inmemorydata.rst
+++ b/docs/source/inmemorydata.rst
@@ -1,0 +1,21 @@
+In Memory Data
+===============
+
+In some cases the data might not come from a database with entity framework core, or elasticsearch, etc.
+When the data is in memory, some operations might not work as expected as when the data comes from a database, such as:
+
+* String comparisons is case insensitive in a database but not in memory
+* Selecting object sub fields will throw null exceptions.
+
+To fix this it is possible to mark a table as being in memory:
+
+.. code-block:: csharp
+
+  opt.AddTableResolver<TestResolver, Test>(o =>
+  {
+    //Mark that this table uses data stored in memory
+    o.UseInMemoryOperations();
+  });
+
+
+This will then add a new operations provider that is suitable to handle in memory operations to still have case insensitive string comparisons and not throwing null exceptions.

--- a/netcore/src/Koralium.Core/Builders/KoraliumBuilder.cs
+++ b/netcore/src/Koralium.Core/Builders/KoraliumBuilder.cs
@@ -76,7 +76,7 @@ namespace Koralium.Builders
                 columns, 
                 securityPolicy, 
                 opt.Indicies,
-                opt.StringOperationsProvider,
+                opt.OperationsProvider,
                 partitionResolver));
 
             return this;

--- a/netcore/src/Koralium.Core/Builders/TableResolverBuilder.cs
+++ b/netcore/src/Koralium.Core/Builders/TableResolverBuilder.cs
@@ -21,7 +21,7 @@ namespace Koralium.Builders
     {
         private readonly List<TableColumn> _columns;
         private readonly List<TableIndex> indicies = new List<TableIndex>();
-        private IStringOperationsProvider _stringOperationsProvider;
+        private IOperationsProvider _operationsProvider;
         public string TableName { get; set; }
         
         internal PartitionResolver PartitionResolver { get; private set; }
@@ -34,11 +34,11 @@ namespace Koralium.Builders
             }
         }
 
-        internal IStringOperationsProvider StringOperationsProvider
+        internal IOperationsProvider OperationsProvider
         {
             get
             {
-                return _stringOperationsProvider;
+                return _operationsProvider;
             }
         }
 
@@ -47,9 +47,9 @@ namespace Koralium.Builders
             _columns = columns;
         }
 
-        public ITableResolverBuilder<Entity> SetStringOperationsProvider(IStringOperationsProvider stringOperationsProvider)
+        public ITableResolverBuilder<Entity> SetOperationsProvider(IOperationsProvider operationsProvider)
         {
-            _stringOperationsProvider = stringOperationsProvider;
+            _operationsProvider = operationsProvider;
             return this;
         }
 

--- a/netcore/src/Koralium.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/netcore/src/Koralium.Core/Extensions/ServiceCollectionExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 tablesMetadata.AddTable(new TableMetadata(
                     table.Name, 
                     table.EntityType,
-                    table.StringOperationsProvider));
+                    table.OperationsProvider));
             }
 
             services.AddSqlToExpression(tablesMetadata);

--- a/netcore/src/Koralium.Core/Extensions/TableResolverBuilderExtensions.cs
+++ b/netcore/src/Koralium.Core/Extensions/TableResolverBuilderExtensions.cs
@@ -13,14 +13,21 @@
  */
 using Koralium.Interfaces;
 using Koralium.SqlToExpression.Providers;
+using System;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     public static class TableResolverBuilderExtensions
     {
+        [Obsolete("Use 'UseInMemoryOperations' instead.")]
         public static ITableResolverBuilder<T> UseInMemoryCaseInsensitiveStringOperations<T>(this ITableResolverBuilder<T> tableResolverBuilder)
         {
-            tableResolverBuilder.SetStringOperationsProvider(new CaseInsensitiveStringOperationsProvider());
+            return tableResolverBuilder.UseInMemoryOperations();
+        }
+
+        public static ITableResolverBuilder<T> UseInMemoryOperations<T>(this ITableResolverBuilder<T> tableResolverBuilder)
+        {
+            tableResolverBuilder.SetOperationsProvider(new InMemoryOperationsProvider());
             return tableResolverBuilder;
         }
     }

--- a/netcore/src/Koralium.Core/Interfaces/ITableResolverBuilder.cs
+++ b/netcore/src/Koralium.Core/Interfaces/ITableResolverBuilder.cs
@@ -19,7 +19,7 @@ namespace Koralium.Interfaces
     {
         string TableName { get; set; }
 
-        ITableResolverBuilder<T> SetStringOperationsProvider(IStringOperationsProvider stringOperationsProvider);
+        ITableResolverBuilder<T> SetOperationsProvider(IOperationsProvider operationsProvider);
 
         ITableResolverBuilder<T> SetPartitionResolver(PartitionResolver partitionResolver);
     }

--- a/netcore/src/Koralium.Core/Metadata/KoraliumTable.cs
+++ b/netcore/src/Koralium.Core/Metadata/KoraliumTable.cs
@@ -32,7 +32,7 @@ namespace Koralium
 
         public IReadOnlyList<TableIndex> Indices { get; }
 
-        public IStringOperationsProvider StringOperationsProvider { get; }
+        public IOperationsProvider OperationsProvider { get; }
 
         public PartitionResolver PartitionResolver { get; }
 
@@ -43,7 +43,7 @@ namespace Koralium
             IReadOnlyList<TableColumn> columns,
             string securityPolicy,
             IReadOnlyList<TableIndex> indices,
-            IStringOperationsProvider stringOperationsProvider,
+            IOperationsProvider operationsProvider,
             PartitionResolver partitionResolver)
         {
             Name = name;
@@ -52,7 +52,7 @@ namespace Koralium
             Columns = columns;
             SecurityPolicy = securityPolicy;
             Indices = indices;
-            StringOperationsProvider = stringOperationsProvider;
+            OperationsProvider = operationsProvider;
             PartitionResolver = partitionResolver;
         }
     }

--- a/netcore/src/Koralium.SqlToExpression/Extensions/ServiceCollectionExtensions.cs
+++ b/netcore/src/Koralium.SqlToExpression/Extensions/ServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ namespace Koralium.SqlToExpression.Extensions
             services.AddSingleton<IOffsetExecutorFactory, DefaultOffsetExecutorFactory>();
             services.AddSingleton<IDistinctExecutorFactory, DefaultDistinctExecutorFactory>();
             services.AddSingleton<ISearchExpressionProvider, DefaultSearchExpressionProvider>();
-            services.AddSingleton<IStringOperationsProvider, DefaultStringOperationsProvider>();
+            services.AddSingleton<IOperationsProvider, DefaultOperationsProvider>();
             services.AddSingleton<IAggregateFunctionExecutorFactory, DefaultAggregateFunctionFactory>();
 
             services.AddScoped<SqlExecutor>();

--- a/netcore/src/Koralium.SqlToExpression/Interfaces/IOperationsProvider.cs
+++ b/netcore/src/Koralium.SqlToExpression/Interfaces/IOperationsProvider.cs
@@ -12,17 +12,20 @@
  * limitations under the License.
  */
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Koralium.SqlToExpression.Interfaces
 {
-    public interface IStringOperationsProvider
+    public interface IOperationsProvider
     {
-        Expression GetEqualsExpressions(Expression left, Expression right);
+        Expression GetStringEqualsExpressions(in Expression left, in Expression right);
 
-        Expression GetStartsWithExpression(Expression left, Expression right);
+        Expression GetStringStartsWithExpression(in Expression left, in Expression right);
 
-        Expression GetEndsWithExpression(Expression left, Expression right);
+        Expression GetStringEndsWithExpression(in Expression left, in Expression right);
 
-        Expression GetContainsExpression(Expression left, Expression right);
+        Expression GetStringContainsExpression(in Expression left, in Expression right);
+
+        Expression MakeSubfieldMemberAccessExpression(in Expression expression, PropertyInfo propertyInfo);
     }
 }

--- a/netcore/src/Koralium.SqlToExpression/Metadata/TableMetadata.cs
+++ b/netcore/src/Koralium.SqlToExpression/Metadata/TableMetadata.cs
@@ -22,16 +22,16 @@ namespace Koralium.SqlToExpression.Metadata
 
         public Type Type { get; }
 
-        public IStringOperationsProvider StringOperationsProvider { get; }
+        public IOperationsProvider OperationsProvider { get; }
 
         public TableMetadata(
             string name, 
             Type type,
-            IStringOperationsProvider stringOperationsProvider = null)
+            IOperationsProvider operationsProvider = null)
         {
             Name = name;
             Type = type;
-            StringOperationsProvider = stringOperationsProvider;
+            OperationsProvider = operationsProvider;
         }
     }
 }

--- a/netcore/src/Koralium.SqlToExpression/Providers/DefaultOperationsProvider.cs
+++ b/netcore/src/Koralium.SqlToExpression/Providers/DefaultOperationsProvider.cs
@@ -1,4 +1,9 @@
-﻿/*
+﻿using Koralium.SqlToExpression.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,37 +16,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using Koralium.SqlToExpression.Interfaces;
-using System;
-using System.Linq.Expressions;
-using System.Reflection;
+using System.Text;
 
 namespace Koralium.SqlToExpression.Providers
 {
-    public class DefaultStringOperationsProvider : IStringOperationsProvider
+    public class DefaultOperationsProvider : IOperationsProvider
     {
         private static readonly MethodInfo StringStartsWith = typeof(string).GetMethod("StartsWith", new Type[] { typeof(string) });
         private static readonly MethodInfo StringContains = typeof(string).GetMethod("Contains", new Type[] { typeof(string) });
         private static readonly MethodInfo StringEndsWith = typeof(string).GetMethod("EndsWith", new Type[] { typeof(string) });
 
-        public Expression GetContainsExpression(Expression left, Expression right)
+        public virtual Expression GetStringContainsExpression(in Expression left, in Expression right)
         {
             return Expression.Call(instance: left, method: StringContains, arguments: new[] { right });
         }
 
-        public Expression GetEndsWithExpression(Expression left, Expression right)
+        public virtual Expression GetStringEndsWithExpression(in Expression left, in Expression right)
         {
             return Expression.Call(instance: left, method: StringEndsWith, arguments: new[] { right });
         }
 
-        public Expression GetEqualsExpressions(Expression left, Expression right)
+        public virtual Expression GetStringEqualsExpressions(in Expression left, in Expression right)
         {
             return Expression.Equal(left, right);
         }
 
-        public Expression GetStartsWithExpression(Expression left, Expression right)
+        public virtual Expression GetStringStartsWithExpression(in Expression left, in Expression right)
         {
             return Expression.Call(instance: left, method: StringStartsWith, arguments: new[] { right });
+        }
+
+        public virtual Expression MakeSubfieldMemberAccessExpression(in Expression expression, PropertyInfo propertyInfo)
+        {
+            return Expression.MakeMemberAccess(expression, propertyInfo);
         }
     }
 }

--- a/netcore/src/Koralium.SqlToExpression/Providers/InMemoryOperationsProvider.cs
+++ b/netcore/src/Koralium.SqlToExpression/Providers/InMemoryOperationsProvider.cs
@@ -112,14 +112,11 @@ namespace Koralium.SqlToExpression.Providers
         #endregion
 
         #region Object subfield select
-
-        private static readonly Expression NullConstant = Expression.Constant(null);
-
         public override Expression MakeSubfieldMemberAccessExpression(in Expression expression, PropertyInfo propertyInfo)
         {
             BinaryExpression nullCheck = Expression.NotEqual(expression, Expression.Constant(null, typeof(object)));
 
-            Expression nullValue = NullConstant;
+            Expression nullValue;
 
             var memberAccess = base.MakeSubfieldMemberAccessExpression(expression, propertyInfo);
 

--- a/netcore/src/Koralium.SqlToExpression/SqlExecutor.cs
+++ b/netcore/src/Koralium.SqlToExpression/SqlExecutor.cs
@@ -34,7 +34,7 @@ namespace Koralium.SqlToExpression
         private readonly StageConverter _stageConverter;
         private readonly IQueryExecutor _queryExecutor;
         private readonly ISearchExpressionProvider _searchExpressionProvider;
-        private readonly IStringOperationsProvider _stringOperationsProvider;
+        private readonly IOperationsProvider _operationsProvider;
 
         private readonly ISqlParser _sqlParser;
         public SqlExecutor(
@@ -42,21 +42,21 @@ namespace Koralium.SqlToExpression
             TablesMetadata tablesMetadata,
             IQueryExecutor queryExecutor,
             ISearchExpressionProvider searchExpressionProvider,
-            IStringOperationsProvider stringOperationsProvider)
+            IOperationsProvider operationsProvider)
         {
             _sqlParser = sqlParser;
             _tablesMetadata = tablesMetadata;
             _queryExecutor = queryExecutor;
             _stageConverter = new StageConverter();
             _searchExpressionProvider = searchExpressionProvider;
-            _stringOperationsProvider = stringOperationsProvider;
+            _operationsProvider = operationsProvider;
         }
 
         public async ValueTask<object> ExecuteScalar(string sql, SqlParameters parameters = null, object data = null)
         {
             sql = OffsetLimitUtils.TransformQuery(sql);
             var tree = _sqlParser.Parse(sql);
-            var mainVisitor = new MainVisitor(new VisitorMetadata(parameters, _tablesMetadata, _searchExpressionProvider, _stringOperationsProvider));
+            var mainVisitor = new MainVisitor(new VisitorMetadata(parameters, _tablesMetadata, _searchExpressionProvider, _operationsProvider));
             tree.Accept(mainVisitor);
 
             //Convert into execute stages
@@ -91,7 +91,7 @@ namespace Koralium.SqlToExpression
                 throw new SqlErrorException(firstError.Message);
             }
 
-            var mainVisitor = new MainVisitor(new VisitorMetadata(parameters, _tablesMetadata, _searchExpressionProvider, _stringOperationsProvider));
+            var mainVisitor = new MainVisitor(new VisitorMetadata(parameters, _tablesMetadata, _searchExpressionProvider, _operationsProvider));
             tree.Accept(mainVisitor);
 
             return mainVisitor.Stages;
@@ -99,7 +99,7 @@ namespace Koralium.SqlToExpression
 
         private IReadOnlyList<IQueryStage> GetStages(StatementList tree, SqlParameters parameters)
         {
-            var mainVisitor = new MainVisitor(new VisitorMetadata(parameters, _tablesMetadata, _searchExpressionProvider, _stringOperationsProvider));
+            var mainVisitor = new MainVisitor(new VisitorMetadata(parameters, _tablesMetadata, _searchExpressionProvider, _operationsProvider));
             tree.Accept(mainVisitor);
 
             return mainVisitor.Stages;

--- a/netcore/src/Koralium.SqlToExpression/Utils/PredicateUtils.cs
+++ b/netcore/src/Koralium.SqlToExpression/Utils/PredicateUtils.cs
@@ -143,31 +143,31 @@ namespace Koralium.SqlToExpression.Utils
         public static Expression CallContains(
             Expression left, 
             Expression value,
-            IStringOperationsProvider stringOperationsProvider)
+            IOperationsProvider operationsProvider)
         {
             ConvertExpressionTypes(ref left, ref value);
-            return stringOperationsProvider.GetContainsExpression(left, value);
+            return operationsProvider.GetStringContainsExpression(left, value);
         }
 
         public static Expression CallStartsWith(
             Expression left, 
             Expression value,
-            IStringOperationsProvider stringOperationsProvider)
+            IOperationsProvider operationsProvider)
         {
             ConvertExpressionTypes(ref left, ref value);
-            return stringOperationsProvider.GetStartsWithExpression(left, value);
+            return operationsProvider.GetStringStartsWithExpression(left, value);
         }
         
         public static Expression CallEndsWith(
             Expression left, 
             Expression value,
-            IStringOperationsProvider stringOperationsProvider)
+            IOperationsProvider operationsProviders)
         {
             ConvertExpressionTypes(ref left, ref value);
-            return stringOperationsProvider.GetEndsWithExpression(left, value);
+            return operationsProviders.GetStringEndsWithExpression(left, value);
         }
 
-        private static Expression HandleEquals(Expression leftExpression, Expression rightExpression, IStringOperationsProvider stringOperationsProvider)
+        private static Expression HandleEquals(Expression leftExpression, Expression rightExpression, IOperationsProvider operationsProviders)
         {
             //Null equal primitive cant be done, automatic false
             if ((IsConstantNull(leftExpression) && rightExpression.Type.IsPrimitive) || (IsConstantNull(rightExpression) && leftExpression.Type.IsPrimitive))
@@ -177,7 +177,7 @@ namespace Koralium.SqlToExpression.Utils
             //String is a special case since one might want to do case insensitive comparisions
             if (leftExpression.Type.Equals(typeof(string)))
             {
-                return stringOperationsProvider.GetEqualsExpressions(leftExpression, rightExpression);
+                return operationsProviders.GetStringEqualsExpressions(leftExpression, rightExpression);
             }
             else
             {
@@ -234,14 +234,14 @@ namespace Koralium.SqlToExpression.Utils
             Expression leftExpression,
             Expression rightExpression,
             BooleanComparisonType comparisonType,
-            IStringOperationsProvider stringOperationsProvider)
+            IOperationsProvider operationsProvider)
         {
             ConvertExpressionTypes(ref leftExpression, ref rightExpression);
 
             switch (comparisonType)
             {
                 case BooleanComparisonType.Equals:
-                    return HandleEquals(leftExpression, rightExpression, stringOperationsProvider);
+                    return HandleEquals(leftExpression, rightExpression, operationsProvider);
                 case BooleanComparisonType.GreaterThan:
                     return HandleGreaterThan(leftExpression, rightExpression);
                 case BooleanComparisonType.GreaterThanOrEqualTo:

--- a/netcore/src/Koralium.SqlToExpression/Visitors/BaseAggregationVisitor.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/BaseAggregationVisitor.cs
@@ -24,9 +24,11 @@ namespace Koralium.SqlToExpression.Visitors
     {
         private bool _inAggregateFunction = false;
         private readonly GroupedStage _previousStage;
+        private readonly VisitorMetadata _visitorMetadata;
         public BaseAggregationVisitor(GroupedStage previousStage, VisitorMetadata visitorMetadata) : base(previousStage, visitorMetadata)
         {
             _previousStage = previousStage;
+            _visitorMetadata = visitorMetadata;
         }
 
         public override void VisitFunctionCall(FunctionCall functionCall)
@@ -55,12 +57,12 @@ namespace Koralium.SqlToExpression.Visitors
             Expression expression;
             if (_inAggregateFunction)
             {
-                expression = MemberUtils.GetMemberGroupByInValue(_previousStage, identifiers, out var property);
+                expression = MemberUtils.GetMemberGroupByInValue(_previousStage, identifiers, _visitorMetadata.OperationsProvider, out var property);
                 AddUsedProperty(property);
             }
             else
             {
-                expression = MemberUtils.GetMemberGroupByInKey(_previousStage, identifiers, out var property);
+                expression = MemberUtils.GetMemberGroupByInKey(_previousStage, identifiers, _visitorMetadata.OperationsProvider, out var property);
                 AddUsedProperty(property);
             }
 

--- a/netcore/src/Koralium.SqlToExpression/Visitors/BaseVisitor.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/BaseVisitor.cs
@@ -91,7 +91,7 @@ namespace Koralium.SqlToExpression.Visitors
             var identifiers = columnReference.Identifiers;
 
             identifiers = MemberUtils.RemoveAlias(_previousStage, identifiers);
-            var memberAccess = MemberUtils.GetMember(_previousStage, identifiers, out var property);
+            var memberAccess = MemberUtils.GetMember(_previousStage, identifiers, _visitorMetadata.OperationsProvider, out var property);
             AddUsedProperty(property);
             AddExpressionToStack(memberAccess);
             AddNameToStack(string.Join(".", identifiers));
@@ -201,7 +201,7 @@ namespace Koralium.SqlToExpression.Visitors
                 leftExpression,
                 rightExpression,
                 booleanComparisonExpression.Type,
-                _visitorMetadata.StringOperationsProvider);
+                _visitorMetadata.OperationsProvider);
 
             AddExpressionToStack(expression);
         }

--- a/netcore/src/Koralium.SqlToExpression/Visitors/From/FromHelper.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/From/FromHelper.cs
@@ -44,9 +44,9 @@ namespace Koralium.SqlToExpression.Visitors.From
             {
                 var type = fromVisitor.Table.Type;
 
-                if (fromVisitor.Table.StringOperationsProvider != null)
+                if (fromVisitor.Table.OperationsProvider != null)
                 {
-                    visitorMetadata.StringOperationsProvider = fromVisitor.Table.StringOperationsProvider;
+                    visitorMetadata.OperationsProvider = fromVisitor.Table.OperationsProvider;
                 }
 
                 stages.Add(new FromTableStage(

--- a/netcore/src/Koralium.SqlToExpression/Visitors/GroupBy/GroupByHelper.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/GroupBy/GroupByHelper.cs
@@ -27,9 +27,10 @@ namespace Koralium.SqlToExpression.Visitors.GroupBy
         public static GroupByStage GetGroupByStage(
             IQueryStage previousStage,
             GroupByClause groupByClause,
-            HashSet<PropertyInfo> usedProperties)
+            HashSet<PropertyInfo> usedProperties,
+            VisitorMetadata visitorMetadata)
         {
-            GroupByVisitor groupByVisitor = new GroupByVisitor(previousStage);
+            GroupByVisitor groupByVisitor = new GroupByVisitor(previousStage, visitorMetadata);
             groupByClause.Accept(groupByVisitor);
 
             foreach (var property in groupByVisitor.UsedProperties)

--- a/netcore/src/Koralium.SqlToExpression/Visitors/GroupBy/GroupByVisitor.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/GroupBy/GroupByVisitor.cs
@@ -25,14 +25,16 @@ namespace Koralium.SqlToExpression.Visitors.GroupBy
         private readonly IQueryStage _previousStage;
         private readonly List<GroupByExpression> _groupByExpressions = new List<GroupByExpression>();
         private readonly List<PropertyInfo> _usedProperties = new List<PropertyInfo>();
+        private readonly VisitorMetadata _visitorMetadata;
 
         public IEnumerable<PropertyInfo> UsedProperties => _usedProperties;
 
         public IReadOnlyList<GroupByExpression> GroupByExpressions => _groupByExpressions;
 
-        public GroupByVisitor(IQueryStage previousStage)
+        public GroupByVisitor(IQueryStage previousStage, VisitorMetadata visitorMetadata)
         {
             _previousStage = previousStage;
+            _visitorMetadata = visitorMetadata;
         }
 
         public override void VisitColumnReference(ColumnReference columnReference)
@@ -40,7 +42,7 @@ namespace Koralium.SqlToExpression.Visitors.GroupBy
             var identifiers = columnReference.Identifiers;
 
             identifiers = MemberUtils.RemoveAlias(_previousStage, identifiers);
-            var memberAccess = MemberUtils.GetMember(_previousStage, identifiers, out var property);
+            var memberAccess = MemberUtils.GetMember(_previousStage, identifiers, _visitorMetadata.OperationsProvider, out var property);
             _usedProperties.Add(property);
 
             _groupByExpressions.Add(new GroupByExpression(memberAccess, string.Join(".", identifiers), property));

--- a/netcore/src/Koralium.SqlToExpression/Visitors/MainVisitor.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/MainVisitor.cs
@@ -96,7 +96,7 @@ namespace Koralium.SqlToExpression.Visitors
         {
             if (selectStatement.GroupByClause != null)
             {
-                _stages.Add(GroupByHelper.GetGroupByStage(LastStage, selectStatement.GroupByClause, _usedProperties));
+                _stages.Add(GroupByHelper.GetGroupByStage(LastStage, selectStatement.GroupByClause, _usedProperties, _visitorMetadata));
             }
             else if (containsAggregates && !IsSimpleAggregate(selectStatement))
             {

--- a/netcore/src/Koralium.SqlToExpression/Visitors/VisitorMetadata.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/VisitorMetadata.cs
@@ -26,13 +26,13 @@ namespace Koralium.SqlToExpression.Visitors
 
         public ISearchExpressionProvider SearchExpressionProvider { get; }
 
-        public IStringOperationsProvider StringOperationsProvider { get; set; }
+        public IOperationsProvider OperationsProvider { get; set; }
 
         public VisitorMetadata(
             SqlParameters sqlParameters, 
             TablesMetadata tablesMetadata, 
             ISearchExpressionProvider searchExpressionProvider,
-            IStringOperationsProvider stringOperationsProvider)
+            IOperationsProvider operationsProvider)
         {
             Debug.Assert(tablesMetadata != null);
 
@@ -46,7 +46,7 @@ namespace Koralium.SqlToExpression.Visitors
             }
             TablesMetadata = tablesMetadata;
             SearchExpressionProvider = searchExpressionProvider;
-            StringOperationsProvider = stringOperationsProvider;
+            OperationsProvider = operationsProvider;
         }
     }
 }

--- a/netcore/src/Koralium.SqlToExpression/Visitors/Where/LikeVisitor.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/Where/LikeVisitor.cs
@@ -182,7 +182,7 @@ namespace Koralium.SqlToExpression.Visitors.Where
             var identifiers = columnReference.Identifiers;
 
             identifiers = MemberUtils.RemoveAlias(_previousStage, identifiers);
-            var memberAccess = MemberUtils.GetMember(_previousStage, identifiers, out var property);
+            var memberAccess = MemberUtils.GetMember(_previousStage, identifiers, _visitorMetadata.OperationsProvider, out var property);
             AddUsedProperty(property);
             return new VisitResult()
             {
@@ -228,7 +228,7 @@ namespace Koralium.SqlToExpression.Visitors.Where
                 expression = PredicateUtils.CallContains(
                     leftExpression,
                     visitResult.Expression,
-                    _visitorMetadata.StringOperationsProvider);
+                    _visitorMetadata.OperationsProvider);
             }
             //Starts with
             else if (visitResult.StartsWith)
@@ -236,7 +236,7 @@ namespace Koralium.SqlToExpression.Visitors.Where
                 expression = PredicateUtils.CallStartsWith(
                     leftExpression,
                     visitResult.Expression,
-                    _visitorMetadata.StringOperationsProvider);
+                    _visitorMetadata.OperationsProvider);
             }
             //Ends with
             else if (visitResult.EndsWith)
@@ -244,7 +244,7 @@ namespace Koralium.SqlToExpression.Visitors.Where
                 expression = PredicateUtils.CallEndsWith(
                     leftExpression,
                     visitResult.Expression,
-                    _visitorMetadata.StringOperationsProvider);
+                    _visitorMetadata.OperationsProvider);
             }
             else
             {
@@ -252,7 +252,7 @@ namespace Koralium.SqlToExpression.Visitors.Where
                     leftExpression,
                     visitResult.Expression,
                     BooleanComparisonType.Equals,
-                    _visitorMetadata.StringOperationsProvider);
+                    _visitorMetadata.OperationsProvider);
             }
 
             if (likeExpression.Not)

--- a/netcore/src/Koralium.SqlToExpression/Visitors/Where/WhereVisitor.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/Where/WhereVisitor.cs
@@ -128,7 +128,7 @@ namespace Koralium.SqlToExpression.Visitors.Where
                 var identifiers = columnReferenceExpression.Identifiers;
 
                 identifiers = MemberUtils.RemoveAlias(_previousStage, identifiers);
-                memberExpression = MemberUtils.GetMember(_previousStage, identifiers, out var property);
+                memberExpression = MemberUtils.GetMember(_previousStage, identifiers, _visitorMetadata.OperationsProvider, out var property);
                 AddUsedProperty(property);
                 AddNameToStack(string.Join(".", identifiers));
             }

--- a/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TpchTestsBase.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TpchTestsBase.cs
@@ -41,13 +41,13 @@ namespace Koralium.SqlToExpression.Tests
             tablesMetadata.AddTable(new TableMetadata("customer", typeof(Customer)));
             tablesMetadata.AddTable(new TableMetadata("lineitem", typeof(LineItem)));
             tablesMetadata.AddTable(new TableMetadata("nation", typeof(Nation)));
-            tablesMetadata.AddTable(new TableMetadata("order", typeof(Order), new CaseInsensitiveStringOperationsProvider()));
+            tablesMetadata.AddTable(new TableMetadata("order", typeof(Order), new InMemoryOperationsProvider()));
             tablesMetadata.AddTable(new TableMetadata("part", typeof(Part)));
             tablesMetadata.AddTable(new TableMetadata("partsupp", typeof(Partsupp)));
             tablesMetadata.AddTable(new TableMetadata("region", typeof(Region)));
             tablesMetadata.AddTable(new TableMetadata("supplier", typeof(Supplier)));
             tablesMetadata.AddTable(new TableMetadata("columntest", typeof(ColumnTest)));
-            tablesMetadata.AddTable(new TableMetadata("nulltest", typeof(NullTest), new CaseInsensitiveStringOperationsProvider()));
+            tablesMetadata.AddTable(new TableMetadata("nulltest", typeof(NullTest), new InMemoryOperationsProvider()));
 
             var queryExecutor = new QueryExecutor(
                 new TableResolver(tpchData),
@@ -65,7 +65,7 @@ namespace Koralium.SqlToExpression.Tests
                 tablesMetadata, 
                 queryExecutor, 
                 new DefaultSearchExpressionProvider(),
-                new DefaultStringOperationsProvider());
+                new DefaultOperationsProvider());
         }
 
         protected void AssertAreEqual(IQueryable expected, IQueryable actual)

--- a/netcore/tests/Koralium.SqlToExpression.Tests/Koralium.SqlToExpression.Tests.csproj
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/Koralium.SqlToExpression.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Koralium.SqlToExpression\Koralium.SqlToExpression.csproj" />
+    <ProjectReference Include="..\Koralium.WebTests\Koralium.WebTests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/netcore/tests/Koralium.SqlToExpression.Tests/TypeTests.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/TypeTests.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using Koralium.SqlToExpression.Tests.Helpers;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Koralium.SqlToExpression.Tests
+{
+    class TypeTests : TypeTestBase
+    {
+        [Test]
+        public async Task TestSelectSubfield()
+        {
+            var actual = await SqlExecutor.Execute("SELECT object.stringValue from typetest");
+            var expected = WebTests.TestData.GetTypeTests().Select(x => new { P0 = (x.Object != null) ? x.Object.StringValue : null });
+
+            AssertAreEqual(expected, actual.Result);
+
+            var actualInt = await SqlExecutor.Execute("SELECT object.intValue from typetest");
+            var expectedInt = WebTests.TestData.GetTypeTests().Select(x => new { P0 = (x.Object != null) ? x.Object.IntValue : default(Nullable<int>) });
+
+            AssertAreEqual(expectedInt, actualInt.Result);
+        }
+    }
+}

--- a/netcore/tests/Koralium.WebTests/Entities/TypeTest.cs
+++ b/netcore/tests/Koralium.WebTests/Entities/TypeTest.cs
@@ -75,7 +75,7 @@ namespace Koralium.WebTests.Entities
         public TypeTestInnerObject Object { get; set; }
 
         //Lists
-        public List<int> IntList { get; set; }
+        public IEnumerable<int> IntList { get; set; }
 
         public List<int?> IntListNullable { get; set; }
 

--- a/netcore/tests/Koralium.WebTests/Entities/TypeTestInnerObject.cs
+++ b/netcore/tests/Koralium.WebTests/Entities/TypeTestInnerObject.cs
@@ -22,5 +22,7 @@ namespace Koralium.WebTests.Entities
         public List<int> IntList { get; set; }
 
         public TypeTestInnerInnerObject Object { get; set; }
+
+        public int IntValue { get; set; }
     }
 }

--- a/netcore/tests/Koralium.WebTests/Startup.cs
+++ b/netcore/tests/Koralium.WebTests/Startup.cs
@@ -92,7 +92,7 @@ namespace Koralium.WebTests
                 opt.AddTableResolver<OrderResolver, Order>(t =>
                 {
                     t.TableName = "orders";
-                    t.UseInMemoryCaseInsensitiveStringOperations();
+                    t.UseInMemoryOperations();
                 });
                 opt.AddTableResolver<PartResolver, Part>();
                 opt.AddTableResolver<PartsuppResolver, Partsupp>();
@@ -105,7 +105,10 @@ namespace Koralium.WebTests
                     t.TableName = "efcustomer";
                 });
 
-                opt.AddTableResolver<TypeTestResolver, TypeTest>();
+                opt.AddTableResolver<TypeTestResolver, TypeTest>(o =>
+                {
+                    o.UseInMemoryOperations();
+                });
 
                 //Specific
                 opt.AddTableResolver<AutoMapperCustomerResolver, AutoMapperCustomer>();
@@ -119,7 +122,7 @@ namespace Koralium.WebTests
                 opt.AddTableResolver<IndexTestResolver, IndexTest>(o =>
                 {
                     o.TableName = "indextest";
-                    o.UseInMemoryCaseInsensitiveStringOperations();
+                    o.UseInMemoryOperations();
                 });
             });
             

--- a/netcore/tests/Koralium.WebTests/TestData.cs
+++ b/netcore/tests/Koralium.WebTests/TestData.cs
@@ -218,6 +218,7 @@ namespace Koralium.WebTests
                         2,
                         3
                     },
+                    IntValue = 321,
                     Object = new TypeTestInnerInnerObject()
                     {
                         StringValue = "test"


### PR DESCRIPTION
This fixes so exceptions are not thrown when selecting a subfield on an object that is null.