### PR TITLE
Added support for variable references in the IN filter

### DIFF
--- a/netcore/src/Koralium.Shared/SqlParameter.cs
+++ b/netcore/src/Koralium.Shared/SqlParameter.cs
@@ -41,6 +41,13 @@ namespace Koralium.Shared
 
         public abstract object GetValue();
 
+        /// <summary>
+        /// Throws SqlErrorException if the value cannot be converted to the type
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        public abstract object GetValue(Type type);
+
         public abstract Type GetValueType();
     }
 
@@ -61,33 +68,41 @@ namespace Koralium.Shared
         private readonly static MemberInfo ValueMemberInfo = typeof(SqlParameter<T>).GetProperty("Value");
         private static Expression GetMemberAccess(Expression parameter) => Expression.MakeMemberAccess(parameter, ValueMemberInfo);
 
-        public override bool TryGetValue<TValue>(out TValue value)
-        {
-            if (!(Value is TValue))
-            {
-                try
-                {
-                    value = (TValue)Convert.ChangeType(Value, typeof(TValue));
-                    return true;
-                }
-                catch (FormatException)
-                {
-                    value = default;
-                    return false;
-                }
-            }
-            value = (TValue)Convert.ChangeType(Value, typeof(TValue));
-            return true;
-        }
+        
 
         public override object GetValue()
         {
             return Value;
         }
 
+        public override object GetValue(Type type)
+        {
+            if (TryGetValue(type, out var value))
+            {
+                return value;
+            }
+            throw new SqlErrorException($"Value '{Value}' could not be converted to type: '{type}'");
+        }
+
         public override Type GetValueType()
         {
             return typeof(T);
+        }
+
+        public override bool TryGetValue<TValue>(out TValue value)
+        {
+            if (Value is TValue convertedValue)
+            {
+                value = convertedValue;
+                return true;
+            }
+            if (TryGetValue(typeof(TValue), out var objectValue))
+            {
+                value = (TValue)objectValue;
+                return true;
+            }
+            value = default;
+            return false;
         }
 
         public override bool TryGetValue(Type type, out object value)

--- a/netcore/src/Koralium.Shared/SqlParameter.cs
+++ b/netcore/src/Koralium.Shared/SqlParameter.cs
@@ -97,21 +97,7 @@ namespace Koralium.Shared
                 value = Value;
                 return true;
             }
-            try
-            {
-                if ( type.IsEnum)
-                {
-                    value = EnumUtils.ConvertToEnum(Value, type);
-                    return true;
-                }
-                value = Convert.ChangeType(Value, type);
-                return true;
-            }
-            catch (FormatException)
-            {
-                value = default;
-                return false;
-            }
+            return TypeConvertUtils.TryConvertToType(Value, type, out value);
         }
     }
 }

--- a/netcore/src/Koralium.Shared/SqlParameters.cs
+++ b/netcore/src/Koralium.Shared/SqlParameters.cs
@@ -42,6 +42,20 @@ namespace Koralium.Shared
             return _parameters.GetEnumerator();
         }
 
+        /// <summary>
+        /// Throws SqlErrorException if the parameter is not found
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public SqlParameter GetParameter(string name)
+        {
+            if (TryGetParameter(name, out var parameter))
+            {
+                return parameter;
+            }
+            throw new SqlErrorException($"Could not find a parameter named: '{name}'");
+        }
+
         public bool TryGetParameter(string name, out SqlParameter sqlParameter)
         {
             if (!name.StartsWith("@"))

--- a/netcore/src/Koralium.Shared/Utils/TypeConvertUtils.cs
+++ b/netcore/src/Koralium.Shared/Utils/TypeConvertUtils.cs
@@ -22,7 +22,6 @@ namespace Koralium.Shared.Utils
 
         public static object ConvertToType(object value, Type type)
         {
-           
             if (type.IsEnum)
             {
                 try
@@ -38,9 +37,9 @@ namespace Koralium.Shared.Utils
             {
                 return Convert.ChangeType(value, type);
             }
-            catch (FormatException)
+            catch (Exception e) when (e is FormatException || e is InvalidCastException)
             {
-                throw new SqlErrorException($"Could not convert value: '{value}' to type: '{type.Name}");
+                throw new SqlErrorException($"Could not convert value: '{value}' to type: '{type.Name}'");
             }
         }
     }

--- a/netcore/src/Koralium.Shared/Utils/TypeConvertUtils.cs
+++ b/netcore/src/Koralium.Shared/Utils/TypeConvertUtils.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Koralium.Shared.Utils
+{
+    internal static class TypeConvertUtils
+    {
+        public static bool TryConvertToType(object value, Type type, out object convertedValue)
+        {
+            try
+            {
+                convertedValue = ConvertToType(value, type);
+                return true;
+            }
+            catch (SqlErrorException)
+            {
+                convertedValue = default;
+                return false;
+            }
+        }
+
+        public static object ConvertToType(object value, Type type)
+        {
+           
+            if (type.IsEnum)
+            {
+                try
+                {
+                    return EnumUtils.ConvertToEnum(value, type);
+                }
+                catch (ArgumentException)
+                {
+                    throw new SqlErrorException($"Could not find a value in enum '{type.Name}' that matched: '{value}'");
+                }
+            }
+            try
+            {
+                return Convert.ChangeType(value, type);
+            }
+            catch (FormatException)
+            {
+                throw new SqlErrorException($"Could not convert value: '{value}' to type: '{type.Name}");
+            }
+        }
+    }
+}

--- a/netcore/src/Koralium.SqlToExpression/Visitors/Where/WhereVisitor.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/Where/WhereVisitor.cs
@@ -147,21 +147,9 @@ namespace Koralium.SqlToExpression.Visitors.Where
                 }
                 else if (value is VariableReference variableReference)
                 {
-                    if (_visitorMetadata.Parameters.TryGetParameter(variableReference.Name, out var sqlParameter))
-                    {
-                        if (sqlParameter.TryGetValue(memberExpression.Type, out var variableValue))
-                        {
-                            list.Add(variableValue);
-                        }
-                        else
-                        {
-                            throw new SqlErrorException($"Value '{sqlParameter.GetValue()}' could not be converted to type: '{memberExpression.Type}'");
-                        }
-                    }
-                    else
-                    {
-                        throw new SqlErrorException($"Could not find a parameter named: '{variableReference.Name}'");
-                    }
+                    var sqlParameter = _visitorMetadata.Parameters.GetParameter(variableReference.Name);
+                    var variableValue = sqlParameter.GetValue(memberExpression.Type);
+                    list.Add(variableValue);
                 }
                 else
                 {

--- a/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TableResolver.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TableResolver.cs
@@ -50,6 +50,8 @@ namespace Koralium.SqlToExpression.Tests
                     return TestData.GetNullTestData();
                 case "enumtable":
                     return TestData.GetEnumTestData();
+                case "objecttable":
+                    return TestData.GetObjectTestData();
             }
             throw new NotImplementedException();
         }

--- a/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TestData.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TestData.cs
@@ -42,6 +42,20 @@ namespace Koralium.SqlToExpression.Tests.Helpers
             }.AsQueryable();
         }
 
+        public static IQueryable<ObjectTest> GetObjectTestData()
+        {
+            return new List<ObjectTest>()
+            {
+                new ObjectTest()
+                {
+                    InnerObject = new InnerObject()
+                    {
+                        Name = "test"
+                    }
+                }
+            }.AsQueryable();
+        }
+
         public static IQueryable<ColumnTest> GetColumnTestData()
         {
             return new List<ColumnTest>()

--- a/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TpchTestsBase.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TpchTestsBase.cs
@@ -49,6 +49,7 @@ namespace Koralium.SqlToExpression.Tests
             tablesMetadata.AddTable(new TableMetadata("columntest", typeof(ColumnTest)));
             tablesMetadata.AddTable(new TableMetadata("nulltest", typeof(NullTest), new InMemoryOperationsProvider()));
             tablesMetadata.AddTable(new TableMetadata("enumtable", typeof(EnumTest)));
+            tablesMetadata.AddTable(new TableMetadata("objecttable", typeof(ObjectTest)));
 
             var queryExecutor = new QueryExecutor(
                 new TableResolver(tpchData),

--- a/netcore/tests/Koralium.SqlToExpression.Tests/Models/ObjectTest.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/Models/ObjectTest.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Koralium.SqlToExpression.Tests.Models
+{
+    public class InnerObject
+    {
+        public string Name { get; set; }
+    }
+    public class ObjectTest
+    {
+        public InnerObject InnerObject { get; set; }
+    }
+}

--- a/netcore/tests/Koralium.SqlToExpression.Tests/QueryTests.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/QueryTests.cs
@@ -1056,6 +1056,15 @@ namespace Koralium.SqlToExpression.Tests
         }
 
         [Test]
+        public void TestInPredicateCantConvertTypeToObject()
+        {
+            Assert.That(async () =>
+            {
+                await SqlExecutor.Execute("SELECT * FROM \"objecttable\" WHERE innerobject in ('test')");
+            }, Throws.InstanceOf<SqlErrorException>().With.Message.EqualTo("Could not convert value: 'test' to type: 'InnerObject'"));
+        }
+
+        [Test]
         public void TestInPredicateCantConvertTypeWithParameters()
         {
             Assert.That(async () =>
@@ -1064,6 +1073,17 @@ namespace Koralium.SqlToExpression.Tests
                 await SqlExecutor.Execute("SELECT * FROM \"enumtable\" WHERE enum in (@P0)", parameters);
             }, Throws.InstanceOf<SqlErrorException>().With.Message.EqualTo("Value 'test' could not be converted to type: 'Koralium.SqlToExpression.Tests.Models.Enum'"));
         }
+
+        [Test]
+        public void TestInPredicateColumnInArrayThrowsError()
+        {
+            Assert.That(async () =>
+            {
+                var parameters = new SqlParameters().Add(SqlParameter.Create("P0", "test"));
+                await SqlExecutor.Execute("SELECT * FROM \"enumtable\" WHERE enum in (c1)", parameters);
+            }, Throws.InstanceOf<SqlErrorException>().With.Message.EqualTo("IN predicate only supports literal or parameter values."));
+        }
+
 
         [Test]
         public void TestSearchFunction()

--- a/netcore/tests/Koralium.SqlToExpression.Tests/QueryTests.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/QueryTests.cs
@@ -1040,48 +1040,49 @@ namespace Koralium.SqlToExpression.Tests
         [Test]
         public void TestInPredicateParameterMissing()
         {
-            Assert.That(async () =>
-            {
-                await SqlExecutor.Execute("SELECT Orderkey, Orderpriority FROM \"order\" WHERE Orderpriority in (@P0)");
-            }, Throws.InstanceOf<SqlErrorException>().With.Message.EqualTo("Could not find a parameter named: '@P0'"));
+            Assert.ThrowsAsync<SqlErrorException>(
+                async () => await SqlExecutor.Execute("SELECT Orderkey, Orderpriority FROM \"order\" WHERE Orderpriority in (@P0)"),
+                "Could not find a parameter named: '@P0'"
+                );
         }
 
         [Test]
         public void TestInPredicateCantConvertTypeToEnum()
         {
-            Assert.That(async () =>
-            {
-                await SqlExecutor.Execute("SELECT * FROM \"enumtable\" WHERE enum in ('test')");
-            }, Throws.InstanceOf<SqlErrorException>().With.Message.EqualTo("Could not find a value in enum 'Enum' that matched: 'test'"));
+            Assert.ThrowsAsync<SqlErrorException>(
+                async () => await SqlExecutor.Execute("SELECT * FROM \"enumtable\" WHERE enum in ('test')"), 
+                "Could not find a value in enum 'Enum' that matched: 'test"
+                );
         }
 
         [Test]
         public void TestInPredicateCantConvertTypeToObject()
         {
-            Assert.That(async () =>
-            {
-                await SqlExecutor.Execute("SELECT * FROM \"objecttable\" WHERE innerobject in ('test')");
-            }, Throws.InstanceOf<SqlErrorException>().With.Message.EqualTo("Could not convert value: 'test' to type: 'InnerObject'"));
+            Assert.ThrowsAsync<SqlErrorException>(
+                async () => await SqlExecutor.Execute("SELECT * FROM \"objecttable\" WHERE innerobject in ('test')"),
+                "Could not convert value: 'test' to type: 'InnerObject'"
+                );
         }
 
         [Test]
         public void TestInPredicateCantConvertTypeWithParameters()
         {
-            Assert.That(async () =>
-            {
-                var parameters = new SqlParameters().Add(SqlParameter.Create("P0", "test"));
-                await SqlExecutor.Execute("SELECT * FROM \"enumtable\" WHERE enum in (@P0)", parameters);
-            }, Throws.InstanceOf<SqlErrorException>().With.Message.EqualTo("Value 'test' could not be converted to type: 'Koralium.SqlToExpression.Tests.Models.Enum'"));
+            Assert.ThrowsAsync<SqlErrorException>(async () =>
+                {
+                    var parameters = new SqlParameters().Add(SqlParameter.Create("P0", "test"));
+                    await SqlExecutor.Execute("SELECT * FROM \"enumtable\" WHERE enum in (@P0)", parameters);
+                },
+                "Value 'test' could not be converted to type: 'Koralium.SqlToExpression.Tests.Models.Enum'"
+                );
         }
 
         [Test]
         public void TestInPredicateColumnInArrayThrowsError()
         {
-            Assert.That(async () =>
-            {
-                var parameters = new SqlParameters().Add(SqlParameter.Create("P0", "test"));
-                await SqlExecutor.Execute("SELECT * FROM \"enumtable\" WHERE enum in (c1)", parameters);
-            }, Throws.InstanceOf<SqlErrorException>().With.Message.EqualTo("IN predicate only supports literal or parameter values."));
+            Assert.ThrowsAsync<SqlErrorException>(
+                async () => await SqlExecutor.Execute("SELECT * FROM \"enumtable\" WHERE enum in (c1)"),
+                "IN predicate only supports literal or parameter values."
+                );
         }
 
 


### PR DESCRIPTION
This is required to allow clients that changes all strings to parameters to function with in filters.
It also brings the sql support more in line with the standard.

This fixes #269

This PR also contains some changes to SqlParameters and SqlParameter to have helper functions that throw SqlErrorException so one does not have to have an if statement and throw the exception everytime. This was required to fix a code smell of too complex code for the in filter handling.