### PR TITLE
Added check if policy name not found

### DIFF
--- a/netcore/src/Koralium.Core/Properties/AssemblyInfo.cs
+++ b/netcore/src/Koralium.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Koralium.Core.Tests")]

--- a/netcore/src/Koralium.Core/Utils/AuthorizationHelper.cs
+++ b/netcore/src/Koralium.Core/Utils/AuthorizationHelper.cs
@@ -38,6 +38,11 @@ namespace Koralium.Core.Utils
                 else
                 {
                     policy = await authorizationPolicyProvider.GetPolicyAsync(securityPolicy);
+
+                    if (policy == null)
+                    {
+                        throw new InvalidOperationException($"No security policy found named '{securityPolicy}'.");
+                    }
                 }
                 var authContext = new AuthorizationHandlerContext(policy.Requirements, user, null);
                 var authHandlers = await authorizationHandlerProvider.GetHandlersAsync(authContext);

--- a/netcore/tests/Koralium.Core.Tests/CheckAuthorizationTests.cs
+++ b/netcore/tests/Koralium.Core.Tests/CheckAuthorizationTests.cs
@@ -1,0 +1,40 @@
+﻿using Koralium.Core.Utils;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Koralium.Core.Tests
+{
+    public class CheckAuthorizationTests
+    {
+        [Test]
+        public void TestMissingPolicy()
+        {
+            Mock<IAuthorizationPolicyProvider> authorizationPolicyMock = new Mock<IAuthorizationPolicyProvider>();
+
+            authorizationPolicyMock.Setup(x => x.GetPolicyAsync(It.IsAny<string>()))
+                .Returns(() =>
+                {
+                    return Task.FromResult<AuthorizationPolicy>(null);
+                });
+
+            Mock<IAuthorizationHandlerProvider> authorizationHandlerMock = new Mock<IAuthorizationHandlerProvider>();
+            Mock<HttpContext> httpContextMock = new Mock<HttpContext>();
+            
+            ServiceCollection services = new ServiceCollection();
+            services.AddSingleton(authorizationPolicyMock.Object);
+            services.AddSingleton(authorizationHandlerMock.Object);
+
+            Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await AuthorizationHelper.CheckAuthorization(services.BuildServiceProvider(), "test", httpContextMock.Object),
+                "No security policy found named 'test'."
+                );
+        }
+    }
+}

--- a/netcore/tests/Koralium.Core.Tests/Koralium.Core.Tests.csproj
+++ b/netcore/tests/Koralium.Core.Tests/Koralium.Core.Tests.csproj
@@ -11,6 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />


### PR DESCRIPTION
This fixes so that a null reference exception is not thrown if a policy is not found for authorization.