### PR TITLE
Fixed so entity framework sql server can parse any match expressions.

### DIFF
--- a/netcore/src/Koralium.SqlToExpression/Interfaces/IOperationsProvider.cs
+++ b/netcore/src/Koralium.SqlToExpression/Interfaces/IOperationsProvider.cs
@@ -27,5 +27,13 @@ namespace Koralium.SqlToExpression.Interfaces
         Expression GetStringContainsExpression(in Expression left, in Expression right);
 
         Expression MakeSubfieldMemberAccessExpression(in Expression expression, PropertyInfo propertyInfo);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="column">The column that the any call is applied on.</param>
+        /// <param name="anyCall">The any call</param>
+        /// <returns></returns>
+        Expression MakeAnyCall(in Expression column, in Expression anyCall);
     }
 }

--- a/netcore/src/Koralium.SqlToExpression/Providers/DefaultOperationsProvider.cs
+++ b/netcore/src/Koralium.SqlToExpression/Providers/DefaultOperationsProvider.cs
@@ -46,6 +46,11 @@ namespace Koralium.SqlToExpression.Providers
             return Expression.Call(instance: left, method: StringStartsWith, arguments: new[] { right });
         }
 
+        public virtual Expression MakeAnyCall(in Expression column, in Expression anyCall)
+        {
+            return anyCall;
+        }
+
         public virtual Expression MakeSubfieldMemberAccessExpression(in Expression expression, PropertyInfo propertyInfo)
         {
             return Expression.MakeMemberAccess(expression, propertyInfo);

--- a/netcore/src/Koralium.SqlToExpression/Providers/InMemoryOperationsProvider.cs
+++ b/netcore/src/Koralium.SqlToExpression/Providers/InMemoryOperationsProvider.cs
@@ -109,6 +109,11 @@ namespace Koralium.SqlToExpression.Providers
             return Expression.Call(instance: null, method: StringStartsWith, arguments: new[] { left, right });
         }
 
+        public override Expression MakeAnyCall(in Expression column, in Expression anyCall)
+        {
+            return Expression.Condition(Expression.Equal(column, Expression.Constant(null, column.Type)), Expression.Constant(false), anyCall);
+        }
+
         #endregion
 
         #region Object subfield select

--- a/netcore/src/Koralium.SqlToExpression/Visitors/BaseVisitor.cs
+++ b/netcore/src/Koralium.SqlToExpression/Visitors/BaseVisitor.cs
@@ -353,9 +353,8 @@ namespace Koralium.SqlToExpression.Visitors
             //Create an expression that calls Any() on the array with the lambda.
             var anyCall = ArrayFunctionUtils.CallAny(elementType, column, lambda);
 
-            var nullCheck = Expression.Condition(Expression.Equal(column, Expression.Constant(null, column.Type)), Expression.Constant(false), anyCall);
-
-            AddExpressionToStack(nullCheck);
+            var result = _visitorMetadata.OperationsProvider.MakeAnyCall(column, anyCall);
+            AddExpressionToStack(result);
         }
 
         private void VisitFilter(FunctionCall functionCall)

--- a/netcore/tests/Koralium.SqlToExpression.Tests/FunctionTests.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/FunctionTests.cs
@@ -14,6 +14,7 @@
 using Koralium.Shared;
 using Koralium.SqlToExpression.Tests.Helpers;
 using NUnit.Framework;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -32,12 +33,39 @@ namespace Koralium.SqlToExpression.Tests
 
         #region any_match
         [Test]
-        public async Task TestSelectAnyMatch()
+        public async Task TestSelectAnyMatchInMemoryProvider()
         {
             var actual = (await SqlExecutor.Execute("SELECT any_match(IntList, x -> x = 1) FROM typetest"));
             var expected = WebTests.TestData.GetTypeTests().Select(x => new { P0 = (x.IntList != null) && x.IntList.Any(y => y == 1) });
 
             AssertAreEqual(expected, actual.Result);
+        }
+
+        [Test]
+        public async Task TestSelectAnyMatchDefaultProvider()
+        {
+            //This test should fail since there are intlists that are null
+            Assert.ThrowsAsync<ArgumentNullException>(async () =>
+            {
+                var actual = (await SqlExecutor.Execute("SELECT any_match(IntList, x -> x = 1) FROM typetestdefaultoperationprovider"));
+                var enumerator = actual.Result.GetEnumerator();
+
+                while (enumerator.MoveNext()) 
+                { 
+                //Do nothing
+                }
+            });
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                var actual = (await SqlExecutor.Execute("SELECT any_match(IntList, x -> x = 1) FROM typetestdefaultoperationprovider WHERE IntList is not null"));
+                var enumerator = actual.Result.GetEnumerator();
+
+                while (enumerator.MoveNext())
+                {
+                    //Do nothing
+                }
+            });
+            
         }
 
         [Test]

--- a/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TypeTestBase.cs
+++ b/netcore/tests/Koralium.SqlToExpression.Tests/Helpers/TypeTestBase.cs
@@ -47,6 +47,7 @@ namespace Koralium.SqlToExpression.Tests.Helpers
             tpchData = new TpchData();
             TablesMetadata tablesMetadata = new TablesMetadata();
             tablesMetadata.AddTable(new TableMetadata("typetest", typeof(TypeTest), new InMemoryOperationsProvider()));
+            tablesMetadata.AddTable(new TableMetadata("typetestdefaultoperationprovider", typeof(TypeTest)));
 
             var queryExecutor = new QueryExecutor(
                 new TypeTestTableResolver(),


### PR DESCRIPTION
Removed column null check from the default behaviour, added it for the in memory.