### PR TITLE
A way to customzie exception-messages / how errors are written to the response

### DIFF
--- a/netcore/src/Koralium.Transport.Json/IErrorWriter.cs
+++ b/netcore/src/Koralium.Transport.Json/IErrorWriter.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Koralium.Transport.Json
+{
+    public interface IErrorWriter
+    {
+        Task WriteAsync(HttpContext context, int statusCode, string message);
+    }
+}


### PR DESCRIPTION
Adds a new interface `IErrorWriter` that allows consumers to implement their own error-writing to the response (or something else). For instance if we want to follow the "ProblemDetails"-standard for writing errors we can do it using this new interface/service. 

Ideally I think hooking in with [UseExceptionHandler](docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.exceptionhandlerextensions.useexceptionhandler?view=aspnetcore-6.0) ([example](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/error-handling?view=aspnetcore-6.0#exception-handler-lambda)) would be ideal. But this might mean koralium doesn't catch any exceptions. Maybe it should be optional. For instance with a new method: 
`MapKoraliumJsonGet(this IEndpointRouteBuilder endpointRouteBuilder, string pattern, bool handleExceptions)`

(Koralium.Transport.Json-exceptions could also be dealt with using the "Exception Handler lambda". Which would allow customization using the IExceptionHandlerPathFeature. But we still would need a way to customize how the response is written.)

This is just small "suggestion" and maybe not the real solution, but something that enables a bit of discussion. 

The solution for GRPC/arrow flight would be different I imagine :)